### PR TITLE
Support default audio and subtitle tracks

### DIFF
--- a/lib/modern_player.dart
+++ b/lib/modern_player.dart
@@ -9,6 +9,7 @@ export 'src/modern_player_options.dart'
         ModernPlayerOptions,
         ModernPlayerVideoData,
         ModernPlayerControlsOptions,
+        ModernPlayerDefaultSelectionOptions,
         ModernPlayerThemeOptions,
         ModernPlayerProgressSliderTheme,
         ModernPlayerCustomActionButton,

--- a/lib/modern_player.dart
+++ b/lib/modern_player.dart
@@ -17,4 +17,7 @@ export 'src/modern_player_options.dart'
         ModernPlayerAudioTrackOptions,
         ModernPlayerToastSliderThemeOption,
         ModernPlayerTranslationOptions,
-        ModernPlayerCallbackOptions;
+        ModernPlayerCallbackOptions,
+        DefaultSelector,
+        DefaultSelectorCustom,
+        DefaultSelectorOff;

--- a/lib/src/modern_player.dart
+++ b/lib/src/modern_player.dart
@@ -20,6 +20,7 @@ class ModernPlayer extends StatefulWidget {
       {required this.video,
       required this.subtitles,
       required this.audioTracks,
+      this.defaultSelectionOptions,
       this.options,
       this.controlsOptions,
       this.themeOptions,
@@ -36,6 +37,9 @@ class ModernPlayer extends StatefulWidget {
 
   /// If you wish to add audio from [file] or [network], you can use this [audioTracks].
   final List<ModernPlayerAudioTrackOptions> audioTracks;
+
+  /// Default selection options for subtitles and audio tracks.
+  final ModernPlayerDefaultSelectionOptions? defaultSelectionOptions;
 
   // Modern player options gives you some basic controls for video
   final ModernPlayerOptions? options;
@@ -56,6 +60,7 @@ class ModernPlayer extends StatefulWidget {
       {required ModernPlayerVideo video,
       List<ModernPlayerSubtitleOptions>? subtitles,
       List<ModernPlayerAudioTrackOptions>? audioTracks,
+      ModernPlayerDefaultSelectionOptions? defaultSelectionOptions,
       ModernPlayerOptions? options,
       ModernPlayerControlsOptions? controlsOptions,
       ModernPlayerThemeOptions? themeOptions,
@@ -67,6 +72,7 @@ class ModernPlayer extends StatefulWidget {
       audioTracks: audioTracks ?? [],
       options: options,
       controlsOptions: controlsOptions,
+      defaultSelectionOptions: defaultSelectionOptions,
       themeOptions: themeOptions,
       translationOptions: translationOptions,
       callbackOptions: callbackOptions,
@@ -281,6 +287,8 @@ class _ModernPlayerState extends State<ModernPlayer> {
                   videos: videosData,
                   controlsOptions:
                       widget.controlsOptions ?? ModernPlayerControlsOptions(),
+                  defaultSelectionOptions: widget.defaultSelectionOptions ??
+                      ModernPlayerDefaultSelectionOptions(),
                   themeOptions:
                       widget.themeOptions ?? ModernPlayerThemeOptions(),
                   translationOptions: widget.translationOptions ??

--- a/lib/src/modern_player_controls.dart
+++ b/lib/src/modern_player_controls.dart
@@ -150,7 +150,7 @@ class _ModernPlayerControlsState extends State<ModernPlayerControls> {
 
     await Future.wait([
       _setDefaultSubtitleTrack(_subtitleTracks),
-      _setDefaultAudioTrack(_subtitleTracks),
+      _setDefaultAudioTrack(_audioTracks),
     ]);
   }
 

--- a/lib/src/modern_player_options.dart
+++ b/lib/src/modern_player_options.dart
@@ -314,6 +314,19 @@ class ModernPlayerCustomActionButton {
       {required this.icon, this.onPressed, this.onDoubleTap, this.onLongPress});
 }
 
+typedef DefaultSelector = bool Function(int index, String label);
+
+class ModernPlayerDefaultSelectionOptions {
+  DefaultSelector? defaultSubtitleSelector;
+  DefaultSelector? defaultAudioSelector;
+  DefaultSelector? defaultQualitySelector;
+
+  ModernPlayerDefaultSelectionOptions(
+      {this.defaultSubtitleSelector,
+      this.defaultAudioSelector,
+      this.defaultQualitySelector});
+}
+
 /// Subtitle Option for Modern Player
 ///
 /// With subtitle option you can add subtitle in video from other sources.

--- a/lib/src/modern_player_options.dart
+++ b/lib/src/modern_player_options.dart
@@ -314,17 +314,29 @@ class ModernPlayerCustomActionButton {
       {required this.icon, this.onPressed, this.onDoubleTap, this.onLongPress});
 }
 
-typedef DefaultSelector = bool Function(int index, String label);
+/// The top level type which defines the strategies for selecting tracks
+sealed class DefaultSelector {}
+
+/// Will default to disabling this track
+class DefaultSelectorOff extends DefaultSelector {}
+
+/// Provide custom logic for selecting a track
+/// It will pick the first track that returns true
+class DefaultSelectorCustom extends DefaultSelector {
+  final bool Function(int index, String label) shouldUseTrack;
+
+  DefaultSelectorCustom(this.shouldUseTrack);
+}
 
 class ModernPlayerDefaultSelectionOptions {
-  DefaultSelector? defaultSubtitleSelector;
-  DefaultSelector? defaultAudioSelector;
-  DefaultSelector? defaultQualitySelector;
+  List<DefaultSelector>? defaultSubtitleSelectors;
+  List<DefaultSelector>? defaultAudioSelectors;
+  List<DefaultSelector>? defaultQualitySelectors;
 
   ModernPlayerDefaultSelectionOptions(
-      {this.defaultSubtitleSelector,
-      this.defaultAudioSelector,
-      this.defaultQualitySelector});
+      {this.defaultSubtitleSelectors,
+      this.defaultAudioSelectors,
+      this.defaultQualitySelectors});
 }
 
 /// Subtitle Option for Modern Player

--- a/lib/src/modern_player_options.dart
+++ b/lib/src/modern_player_options.dart
@@ -328,6 +328,24 @@ class DefaultSelectorCustom extends DefaultSelector {
   DefaultSelectorCustom(this.shouldUseTrack);
 }
 
+/// A [DefaultSelectorCustom] that gets initialized with a string
+/// and selects the first track with a label that contains the string.
+///
+/// Example usage:
+/// ```dart
+/// defaultSubtitleSelectors: [
+///       // Matches "English", "english", "ENG", "eng", etc.
+///       DefaultSelectorLabel("Eng"),
+///       // Falls back to [DefaultSelectorOff] if no other track matches
+///       DefaultSelectorOff(),
+///     ],
+/// ```
+class DefaultSelectorLabel extends DefaultSelectorCustom {
+  DefaultSelectorLabel(String labelSubstring)
+      : super((index, label) =>
+            label.toLowerCase().contains(labelSubstring.toLowerCase()));
+}
+
 class ModernPlayerDefaultSelectionOptions {
   List<DefaultSelector>? defaultSubtitleSelectors;
   List<DefaultSelector>? defaultAudioSelectors;


### PR DESCRIPTION
Fixes: https://github.com/itsSagarBro/modern_player/issues/3

### Summary

Adds support for automatically selecting a subtitle or audio track based on provided criteria.

### Implementation
* For tracks embedded in the file (automatically selected ones), we need to wait for the player to load the file first
* We have the `_getTracks` function which is only invoked when first loaded or a refresh is required (via changeVidoeQuility)
   * Note: this is only technically true given the current implementation. On an adaptive stream, you could change quality but not be required to reload the tracks. 
   * It might be worth preventing the track from changing if one is already selected (and the subtitles don't change) in the future.
* Automatically select the default track based on the provided criteria, or no-op

This PR does _not_ add quality selection. In an adaptive stream, it'd look similar to text and audio, but I believe this is using multiple provided URLs.

### Example

This example shows us automatically selecting a default language of "English". 
```dart
ModernPlayer.createPlayer(
  controlsOptions: ModernPlayerControlsOptions(showBackbutton: false),
  defaultSelectionOptions: ModernPlayerDefaultSelectionOptions(
    defaultSubtitleSelectors: [
      DefaultSelectorCustom((key, value) =>
          value.toLowerCase().contains('english') ||
          value.toLowerCase().contains('en')),
      DefaultSelectorOff(),
    ],
    defaultAudioSelectors: [
      DefaultSelectorCustom((key, value) =>
          value.toLowerCase().contains('english') ||
          value.toLowerCase().contains('en'))
    ],
  ),
  video: ModernPlayerVideo.single(ModernPlayerVideoData.network(
    label: "Default",
    url: "myNetworkUrl",
  )));
```

### Questions
* Instead of having its own "options" class, it could have been bundled with "controls". 

### Future Steps
- [ ] Offer an enum (or ISO 639 support) that simplifies language selection (so each person doesn't need to do the "contains" check themselves).
- [x] Provide an ordered lists of "default" languages, so for example, if English isn't available it falls back to Spanish.
- [ ] Add quality selection