### PR TITLE
fix: :iphone: enhance Modal Bottom Sheets with scrolling ability

### DIFF
--- a/lib/src/modern_player_controls.dart
+++ b/lib/src/modern_player_controls.dart
@@ -849,91 +849,95 @@ class _ModernPlayerControlsState extends State<ModernPlayerControls> {
       showDragHandle: true,
       backgroundColor: getMenuBackgroundColor(),
       constraints: const BoxConstraints(maxWidth: 400),
-      builder: (context) => Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 5),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            GestureDetector(
-              onTap: () {
-                Navigator.pop(context);
-                ModernPlayerMenus().showQualityOptions(context,
-                    menuColor: getMenuBackgroundColor(),
-                    currentData: _currentVideoData,
-                    allData: widget.videos,
-                    onChangedQuality: _changeVideoQuality);
-              },
-              child: Row(
-                children: [
-                  const Icon(
-                    Icons.settings_outlined,
-                    color: Colors.white,
-                  ),
-                  const SizedBox(
-                    width: 20,
-                  ),
-                  Text(
-                    "${translationOptions.qualityHeaderText ?? "Quality"}  ◉  ",
-                    style: const TextStyle(color: Colors.white, fontSize: 16),
-                  ),
-                  Text(
-                    _currentVideoData.label,
-                    style: const TextStyle(color: Colors.white60, fontSize: 16),
-                  )
-                ],
+      builder: (context) => SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 5),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              GestureDetector(
+                onTap: () {
+                  Navigator.pop(context);
+                  ModernPlayerMenus().showQualityOptions(context,
+                      menuColor: getMenuBackgroundColor(),
+                      currentData: _currentVideoData,
+                      allData: widget.videos,
+                      onChangedQuality: _changeVideoQuality);
+                },
+                child: Row(
+                  children: [
+                    const Icon(
+                      Icons.settings_outlined,
+                      color: Colors.white,
+                    ),
+                    const SizedBox(
+                      width: 20,
+                    ),
+                    Text(
+                      "${translationOptions.qualityHeaderText ?? "Quality"}  ◉  ",
+                      style: const TextStyle(color: Colors.white, fontSize: 16),
+                    ),
+                    Text(
+                      _currentVideoData.label,
+                      style:
+                          const TextStyle(color: Colors.white60, fontSize: 16),
+                    )
+                  ],
+                ),
               ),
-            ),
-            const SizedBox(
-              height: 30,
-            ),
-            GestureDetector(
-              onTap: () {
-                Navigator.pop(context);
-                ModernPlayerMenus().showPlabackSpeedOptions(context,
-                    menuColor: getMenuBackgroundColor(),
-                    text:
-                        translationOptions.defaultPlaybackSpeedText ?? "Normal",
-                    currentSpeed: player.value.playbackSpeed,
-                    allSpeeds: _playbackSpeeds, onChnagedSpeed: (speed) {
-                  player.setPlaybackSpeed(speed);
-                  widget.callbackOptions.onChangedPlaybackSpeed?.call(speed);
-                });
-              },
-              child: Row(
-                children: [
-                  const Icon(
-                    Icons.speed_rounded,
-                    color: Colors.white,
-                  ),
-                  const SizedBox(
-                    width: 20,
-                  ),
-                  Text(
-                    "${translationOptions.playbackSpeedText ?? "Plaback speed"}  ◉  ",
-                    style: const TextStyle(color: Colors.white, fontSize: 16),
-                  ),
-                  Text(
-                    player.value.playbackSpeed == 1
-                        ? translationOptions.defaultPlaybackSpeedText ??
-                            "Normal"
-                        : "${player.value.playbackSpeed.toStringAsFixed(2)}x",
-                    style: const TextStyle(color: Colors.white60, fontSize: 16),
-                  )
-                ],
+              const SizedBox(
+                height: 30,
               ),
-            ),
-            const SizedBox(
-              height: 30,
-            ),
-            _subtitleRowWidget(context),
-            const SizedBox(
-              height: 30,
-            ),
-            _audioRowWidget(context),
-            const SizedBox(
-              height: 10,
-            ),
-          ],
+              GestureDetector(
+                onTap: () {
+                  Navigator.pop(context);
+                  ModernPlayerMenus().showPlabackSpeedOptions(context,
+                      menuColor: getMenuBackgroundColor(),
+                      text: translationOptions.defaultPlaybackSpeedText ??
+                          "Normal",
+                      currentSpeed: player.value.playbackSpeed,
+                      allSpeeds: _playbackSpeeds, onChnagedSpeed: (speed) {
+                    player.setPlaybackSpeed(speed);
+                    widget.callbackOptions.onChangedPlaybackSpeed?.call(speed);
+                  });
+                },
+                child: Row(
+                  children: [
+                    const Icon(
+                      Icons.speed_rounded,
+                      color: Colors.white,
+                    ),
+                    const SizedBox(
+                      width: 20,
+                    ),
+                    Text(
+                      "${translationOptions.playbackSpeedText ?? "Plaback speed"}  ◉  ",
+                      style: const TextStyle(color: Colors.white, fontSize: 16),
+                    ),
+                    Text(
+                      player.value.playbackSpeed == 1
+                          ? translationOptions.defaultPlaybackSpeedText ??
+                              "Normal"
+                          : "${player.value.playbackSpeed.toStringAsFixed(2)}x",
+                      style:
+                          const TextStyle(color: Colors.white60, fontSize: 16),
+                    )
+                  ],
+                ),
+              ),
+              const SizedBox(
+                height: 30,
+              ),
+              _subtitleRowWidget(context),
+              const SizedBox(
+                height: 30,
+              ),
+              _audioRowWidget(context),
+              const SizedBox(
+                height: 10,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/src/widgets/modern_player_menus.dart
+++ b/lib/src/widgets/modern_player_menus.dart
@@ -13,48 +13,50 @@ class ModernPlayerMenus {
       showDragHandle: true,
       backgroundColor: menuColor,
       constraints: const BoxConstraints(maxWidth: 400),
-      builder: (context) => Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 5),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ...allData.map(
-              (e) => InkWell(
-                onTap: () {
-                  if (e.label != currentData.label) {
-                    Navigator.pop(context);
-                    onChangedQuality.call(e);
-                  }
-                },
-                child: Container(
-                  margin: const EdgeInsets.symmetric(vertical: 8),
-                  child: Row(
-                    children: [
-                      if (e.label == currentData.label)
-                        const SizedBox(
-                          width: 15,
-                          child: Icon(
-                            Icons.check_rounded,
-                            color: Colors.white,
+      builder: (context) => SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 5),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ...allData.map(
+                (e) => InkWell(
+                  onTap: () {
+                    if (e.label != currentData.label) {
+                      Navigator.pop(context);
+                      onChangedQuality.call(e);
+                    }
+                  },
+                  child: Container(
+                    margin: const EdgeInsets.symmetric(vertical: 8),
+                    child: Row(
+                      children: [
+                        if (e.label == currentData.label)
+                          const SizedBox(
+                            width: 15,
+                            child: Icon(
+                              Icons.check_rounded,
+                              color: Colors.white,
+                            ),
                           ),
+                        SizedBox(
+                          width: e.label == currentData.label ? 20 : 35,
                         ),
-                      SizedBox(
-                        width: e.label == currentData.label ? 20 : 35,
-                      ),
-                      Text(
-                        e.label,
-                        style:
-                            const TextStyle(color: Colors.white, fontSize: 16),
-                      ),
-                    ],
+                        Text(
+                          e.label,
+                          style: const TextStyle(
+                              color: Colors.white, fontSize: 16),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
               ),
-            ),
-            const SizedBox(
-              height: 10,
-            )
-          ],
+              const SizedBox(
+                height: 10,
+              )
+            ],
+          ),
         ),
       ),
     );
@@ -72,48 +74,50 @@ class ModernPlayerMenus {
       showDragHandle: true,
       backgroundColor: menuColor,
       constraints: const BoxConstraints(maxWidth: 400),
-      builder: (context) => Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 5),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ...allSpeeds.map(
-              (e) => InkWell(
-                onTap: () {
-                  if (e != currentSpeed) {
-                    Navigator.pop(context);
-                    onChnagedSpeed.call(e);
-                  }
-                },
-                child: Container(
-                  margin: const EdgeInsets.symmetric(vertical: 8),
-                  child: Row(
-                    children: [
-                      if (e == currentSpeed)
-                        const SizedBox(
-                          width: 15,
-                          child: Icon(
-                            Icons.check_rounded,
-                            color: Colors.white,
+      builder: (context) => SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 5),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ...allSpeeds.map(
+                (e) => InkWell(
+                  onTap: () {
+                    if (e != currentSpeed) {
+                      Navigator.pop(context);
+                      onChnagedSpeed.call(e);
+                    }
+                  },
+                  child: Container(
+                    margin: const EdgeInsets.symmetric(vertical: 8),
+                    child: Row(
+                      children: [
+                        if (e == currentSpeed)
+                          const SizedBox(
+                            width: 15,
+                            child: Icon(
+                              Icons.check_rounded,
+                              color: Colors.white,
+                            ),
                           ),
+                        SizedBox(
+                          width: e == currentSpeed ? 20 : 35,
                         ),
-                      SizedBox(
-                        width: e == currentSpeed ? 20 : 35,
-                      ),
-                      Text(
-                        e == 1 ? text : "${e.toStringAsFixed(2)}x",
-                        style:
-                            const TextStyle(color: Colors.white, fontSize: 16),
-                      ),
-                    ],
+                        Text(
+                          e == 1 ? text : "${e.toStringAsFixed(2)}x",
+                          style: const TextStyle(
+                              color: Colors.white, fontSize: 16),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
               ),
-            ),
-            const SizedBox(
-              height: 10,
-            )
-          ],
+              const SizedBox(
+                height: 10,
+              )
+            ],
+          ),
         ),
       ),
     );
@@ -170,9 +174,9 @@ class ModernPlayerMenus {
       showDragHandle: true,
       backgroundColor: menuColor,
       constraints: const BoxConstraints(maxWidth: 400),
-      builder: (context) => Container(
-        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 5),
-        child: SingleChildScrollView(
+      builder: (context) => SingleChildScrollView(
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 5),
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
@@ -199,9 +203,9 @@ class ModernPlayerMenus {
       showDragHandle: true,
       backgroundColor: menuColor,
       constraints: const BoxConstraints(maxWidth: 400),
-      builder: (context) => Container(
-        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 5),
-        child: SingleChildScrollView(
+      builder: (context) => SingleChildScrollView(
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 5),
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [


### PR DESCRIPTION
Hello 👋🏻

This PR introduces scrolling functionality to modal bottom sheets to prevent UI overflow on smaller screens and in landscape mode. By enabling scrolling, we ensure that all content within the bottom sheets remains fully accessible, regardless of device screen size or orientation. This enhancement improves the overall user experience and responsiveness of the application 🚀.

Please review and let me know if any adjustments are needed. 😊

Thanks 🙏🏻